### PR TITLE
fix(tap_card): always notify host on WebView onReady (REG-66)

### DIFF
--- a/tapcardformkit/src/main/java/company/tap/tapcardformkit/open/web_wrapper/TapCardKit.kt
+++ b/tapcardformkit/src/main/java/company/tap/tapcardformkit/open/web_wrapper/TapCardKit.kt
@@ -25,8 +25,6 @@ import company.tap.tapcardformkit.open.web_wrapper.data.CardFormWebStatus
 import company.tap.tapcardformkit.open.web_wrapper.data.CardWebUrlPrefix
 import company.tap.tapcardformkit.open.web_wrapper.data.network.model.ThreeDsResponse
 import company.tap.tapcardformkit.open.web_wrapper.presentation.nfc_activity.nfcbottomsheet.NFCBottomSheetActivity
-import company.tap.tapcardformkit.open.web_wrapper.data.cache.pref.Pref
-import company.tap.tapcardformkit.open.web_wrapper.data.firstRunKeySharedPrefrence
 import company.tap.tapcardformkit.open.web_wrapper.data.keyValueName
 import company.tap.tapcardformkit.open.web_wrapper.data.urlWebStarter
 import company.tap.tapcardformkit.open.web_wrapper.internal.ThemeManager
@@ -264,46 +262,18 @@ class TapCardKit : LinearLayout {
                  * listen for states of cardWebStatus of onReady , onValidInput .. etc
                  */
                 if (request?.url.toString().contains(CardFormWebStatus.onReady.name)) {
-                    /**
-                     * this scenario only for the first launch of the app , due to issue navigation
-                     * of webview after shimmering , if issue appears [in first install only] init function isCalled again .
-                     *
-                     *
-                     */
-                    val isFirstTime = Pref.getValue(context, firstRunKeySharedPrefrence, "true")
-                    if (isFirstTime == "true") {
-                        init()
-                        Pref.setValue(context, firstRunKeySharedPrefrence, "false")
-                    } else {
-                        CardDataConfiguration.getTapCardStatusListener()?.onCardReady()
-                        /**
-                         * here we send ip Address to front end
-                         */
-                        if (userIpAddress.isNotEmpty()) {
-                            setIpAddress(userIpAddress)
-                        }
-                        /**
-                         * here we ensure prefilling card with numbers passed from merchant
-                         * commented for now
-                         */
-
-                        when (cardPrefillPair.first.isNotBlank()) {
-                            true -> {
-                                if (cardPrefillPair.first.length >= 7) {
-                                    fillCardNumber(
-                                        cardNumber = cardPrefillPair.first,
-                                        expiryDate = cardPrefillPair.second,
-                                        cardExtraPrefillPair.first,
-                                        cardExtraPrefillPair.second
-                                    )
-                                }
-                            }
-
-                            false -> {}
-                        }
-
+                    CardDataConfiguration.getTapCardStatusListener()?.onCardReady()
+                    if (userIpAddress.isNotEmpty()) {
+                        setIpAddress(userIpAddress)
                     }
-
+                    if (cardPrefillPair.first.isNotBlank() && cardPrefillPair.first.length >= 7) {
+                        fillCardNumber(
+                            cardNumber = cardPrefillPair.first,
+                            expiryDate = cardPrefillPair.second,
+                            cardExtraPrefillPair.first,
+                            cardExtraPrefillPair.second
+                        )
+                    }
                 }
                 if (request?.url.toString().contains(CardFormWebStatus.onValidInput.name)) {
                     val validInputValue =


### PR DESCRIPTION
## Summary

- Fixes [REG-66 — Android - Tap - App keep loading](https://barakacorp.atlassian.net/browse/REG-66): the Add Card flow kept loading indefinitely on a fresh install when the user went through tokenization for the first time.
- Removes the broken `isFirstTime` gate in `TapCardKit.onReady` and always invokes the host-facing callbacks (`onCardReady`, `setIpAddress`, `fillCardNumber`).

## Root cause

In `TapCardKit.kt`, the `onReady` handler was wrapped in an `isFirstTime` branch backed by a SharedPreferences flag:

```kotlin
if (isFirstTime == "true") {
    init()                                      // no-op (cardUrlPrefix already set)
    Pref.setValue(context, "firstRun", "false")
} else {
    CardDataConfiguration.getTapCardStatusListener()?.onCardReady()
    setIpAddress(...)
    fillCardNumber(...)
}
```

The comment in the code describes an old workaround for a shimmer/navigation issue on first install, but the implementation is broken: `init()` early-returns when `cardUrlPrefix != null`, which is always the case by the time `onReady` fires. Consequence on the very first launch after a fresh install:

- `onCardReady` is never emitted to the host app
- `setIpAddress` is never called
- `fillCardNumber` is never called
- The host's loading indicator, lit right before `configureWithTapCardDictionaryConfiguration`, never gets turned off → "app keep loading"

The pref is then flipped to `"false"`, so the 2nd attempt goes through the `else` branch and works.

### Why QA only saw it on Bahrain/Oman accounts

The `firstRun` pref is stored globally per-app-install in `company_tap_tapcardformkit.xml`, not per-user. The `fachrul+bahrain@getbaraka.com` / `fachrul+oman@getbaraka.com` test accounts were exercised on dedicated fresh installs for the regression pass, so they reproduced 100% of the time. Devices where the form had been used before had `firstRun="false"` already and never reproduced the bug — regardless of card country. The country correlation in the ticket was coincidental.

## Fix

Drop the `isFirstTime` gate entirely. Always invoke `onCardReady`, `setIpAddress` and `fillCardNumber` on every `onReady` event. The prefill call is still guarded by `cardPrefillPair.first.isNotBlank() && length >= 7`, so it only fires when the host passed prefill values.

The unused `Pref` and `firstRunKeySharedPrefrence` imports are removed. The constant and `Pref` helper file are left in place to minimize the surface of this PR (they can be cleaned up in a follow-up if no other consumer surfaces).

## Risk assessment

- The `else` branch (currently used on all attempts after the first) becomes the sole code path. Users whose pref was already `"false"` see no behavioral change.
- `onCardReady` handler in `baraka-android` (`AddCardFormFragment`) only toggles the loading indicator off — safe to invoke once per `onReady`.
- `fillCardNumber` remains guarded, so no empty JS inject.
- The original `init()` workaround was a silent no-op; removing it cannot introduce a regression.

## Test plan

- [ ] `adb shell pm clear <package>` to simulate a fresh install.
- [ ] Open Add Card on a non-UAE account (e.g. `fachrul+bahrain@getbaraka.com`).
- [ ] Enter or scan a card — form should be interactive on the 1st attempt (was stuck on shimmer before).
- [ ] Generate token → success.
- [ ] Verify the 2nd attempt still works (regression guard for the `else` branch path).
- [ ] Verify UAE accounts still work.
- [ ] Smoke-test NFC scan + card scanner entry points (they share the same `onReady` path).

## Baseline

This PR is built on top of `main` after syncing with `Tap-Payments/Card-Android:main` (4 commits rapatriated in the preceding merge commit `a559f32`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)